### PR TITLE
Throw ExtensibilityException when an extension constructor throws

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,4 +1,4 @@
-next-version: 3.0.3
+next-version: 3.2.0
 mode: ContinuousDelivery
 legacy-semver-padding: 5
 build-metadata-padding: 5

--- a/src/testcentric.extensibility.fakes/FakeExtensions.cs
+++ b/src/testcentric.extensibility.fakes/FakeExtensions.cs
@@ -95,6 +95,20 @@ namespace TestCentric.Engine.Extensibility
             throw new NotImplementedException();
         }
     }
+
+    [Extension(Enabled = false)]
+    public class FakeExtension_ThrowsInConstructor : ITestEventListener
+    {
+        public FakeExtension_ThrowsInConstructor()
+        {
+            throw new NotImplementedException();
+        }
+
+        public void OnTestEvent(string text)
+        {
+            throw new System.NotImplementedException();
+        }
+    }
 }
 
 namespace NUnit.Engine.Extensibility

--- a/src/testcentric.extensibility.tests/ExtensionManagerTests.cs
+++ b/src/testcentric.extensibility.tests/ExtensionManagerTests.cs
@@ -143,6 +143,7 @@ namespace TestCentric.Extensibility
         [
             "TestCentric.Engine.Extensibility.FakeAgentLauncher",
             "TestCentric.Engine.Extensibility.FakeTestEventListener",
+            "TestCentric.Engine.Extensibility.FakeExtension_ThrowsInConstructor",
             "NUnit.Engine.Extensibility.FakeProjectLoader"
         ];
 
@@ -169,6 +170,18 @@ namespace TestCentric.Extensibility
             Assert.That(ExtensionManager.Extensions,
                 Has.One.Property(nameof(ExtensionNode.TypeName)).EqualTo("TestCentric.Engine.Extensibility.FakeTestEventListener")
                    .And.Property(nameof(ExtensionNode.Enabled)).True);
+        }
+
+        [Test]
+        public void ExtensionThrowsInConstructor()
+        {
+            string typeName = "TestCentric.Engine.Extensibility.FakeExtension_ThrowsInConstructor";
+            var iexNode = ExtensionManager.Extensions.Where(n => n.TypeName == typeName).Single();
+            var exNode = iexNode as ExtensionNode;
+
+            // Demonstrates that the exception is caused when ExtensionObject is accessed
+            var tiex = Assert.Throws<ExtensibilityException>(() => { var o = exNode.ExtensionObject; });
+            Assert.That(tiex.InnerException, Is.InstanceOf<NotImplementedException>());
         }
 
 #if NETCOREAPP

--- a/src/testcentric.extensibility/ExtensionNode.cs
+++ b/src/testcentric.extensibility/ExtensionNode.cs
@@ -121,14 +121,23 @@ namespace TestCentric.Extensibility
         /// </summary>
         public object CreateExtensionObject(params object[] args)
         {
+            try
+            {
 #if NETFRAMEWORK
             return AppDomain.CurrentDomain.CreateInstanceFromAndUnwrap(
                 AssemblyPath, TypeName, false, 0, null, args, null, null, null);
 #else
-            var assembly = Assembly.LoadFrom(AssemblyPath);
-            var type = assembly.GetType(TypeName, throwOnError: true)!;
-            return Activator.CreateInstance(type, args)!;
+                var assembly = Assembly.LoadFrom(AssemblyPath);
+                var type = assembly.GetType(TypeName, throwOnError: true)!;
+                return Activator.CreateInstance(type, args)!;
 #endif
+            }
+            catch (Exception ex)
+            {
+                if (ex is TargetInvocationException)
+                    ex = ex.InnerException;
+                throw new ExtensibilityException("Error in constructing extension object", ex);
+            }
         }
 
 #endregion


### PR DESCRIPTION
Fixes #55 

This is the low-level fix for the problem reported... i.e. the GUI crashing when an extension constructor  throws an exception. Within this package, we can only ensure that the situation is reported properly, so `ExtensionNode.CreateExtensionObject()` now throws an `ExtensibilityException when extension constructor fails. It's up to higher-level modules to decide how to handle this.